### PR TITLE
Fix leaf bundle in /activities

### DIFF
--- a/content/activities/_index.md
+++ b/content/activities/_index.md
@@ -1,5 +1,6 @@
 ---
 type: "page"
+layout: "single"
 title: "QGIS User Conference 2026"
 subtitle: "5-6 October 2026, Laax, Switzerland"
 heroImage: "hero.webp"


### PR DESCRIPTION
<!-- Make a "Fixes #" line for each issue you want to close -->
Fixes #

### Summary of the Fixes
<!-- Include a short description for each of the changes made. This will help the reviewer -->

The file `content/activities/index.md` makes activities/a leaf bundle in Hugo. Leaf bundles cannot have sub-pages because their subdirectories are treated as resources, not independent pages. That's why /activities/workshops/ returns a 404.

The fix is to rename it to _index.md (making it a branch bundle/section) and add layout: "single" so it keeps using the single.html template instead of the list template. 
